### PR TITLE
[AOS] 음악 재생 흐름 감지 코드 제거

### DIFF
--- a/android/src/main/java/com/actionpower.audiorecorder/RNAudioRecorderPlayerModule.kt
+++ b/android/src/main/java/com/actionpower.audiorecorder/RNAudioRecorderPlayerModule.kt
@@ -132,7 +132,6 @@ class RNAudioRecorderModule(private val reactContext: ReactApplicationContext) :
                     val maxAmplitude = mediaRecorder?.maxAmplitude ?: 0
                     val dB = if(maxAmplitude != null && maxAmplitude > 0) { 20 * log10(maxAmplitude / 32767.0) } else -160.0
 
-                    val musicStreamActivated = audioManager?.isMusicActive ?: false
                     var isSilenced = false
 
                     if(Build.VERSION.SDK_INT >= 29) {
@@ -150,14 +149,14 @@ class RNAudioRecorderModule(private val reactContext: ReactApplicationContext) :
                         sendEvent(reactContext, "rn-recordback", obj)
                     }
 
-                    if(isSilenced || musicStreamActivated) {
+                    if(isSilenced) {
                         if (!isInterrupted) {
                             obj.putString("status", "pausedByNative")
                             sendEvent(reactContext, "rn-recordback", obj)
                             isInterrupted = true
                             pauseTask()
                         }
-                    } else if(isSilenced == false && musicStreamActivated == false){
+                    } else {
                         if(isInterrupted) {
                             isInterrupted = false
                             obj.putString("status", "resumeByNative")


### PR DESCRIPTION

길지 않은 내용이여서 짧게 PR 드립니다.

audioManager에 필드 값 중, music stream 출력의 필드값을 이용한 녹음 방지 루틴을 제거합니다.

기대효과 :  소리가 나오는 액션에 대하여, 녹음에 간섭이 없어집니다. (단, 마이크에 대한 접근 충돌은 이전과 동일하게 interrupt 됩니다.)

